### PR TITLE
refactor: consolidate hexToBytes and bytesToHex implementations

### DIFF
--- a/src/shared/emv.ts
+++ b/src/shared/emv.ts
@@ -4,6 +4,8 @@
  * main and renderer processes.
  */
 
+import { hexToBytes } from './tlv';
+
 /**
  * AFL (Application File Locator) entry structure
  */
@@ -128,20 +130,6 @@ export function buildSelectPseCommand(): number[] {
  */
 export function buildSelectPpseCommand(): number[] {
   return buildSelectCommand(stringToBytes(PPSE_NAME));
-}
-
-/**
- * Convert hex string to byte array.
- * @param hex - Hex string (with or without spaces)
- * @returns Byte array
- */
-function hexToBytes(hex: string): number[] {
-  const cleanHex = hex.replace(/\s/g, '');
-  const bytes: number[] = [];
-  for (let i = 0; i < cleanHex.length; i += 2) {
-    bytes.push(parseInt(cleanHex.substring(i, i + 2), 16));
-  }
-  return bytes;
 }
 
 /**

--- a/src/shared/handlers/calypso-handler.ts
+++ b/src/shared/handlers/calypso-handler.ts
@@ -23,6 +23,7 @@ import type {
   InterrogationResult,
   ApplicationInfo,
 } from './types';
+import { hexToBytes, bytesToHex } from '../tlv';
 
 /**
  * Calypso Application Identifiers.
@@ -488,7 +489,7 @@ export class CalypsoHandler implements CardHandler {
     sendCommand: (apdu: number[]) => Promise<Response>,
     aid: string
   ): Promise<Response> {
-    const aidBytes = this.hexToBytes(aid);
+    const aidBytes = hexToBytes(aid);
     // SELECT by DF name: 94 A4 04 00 Lc [AID]
     // Calypso uses CLA=0x94 for Rev 1/2, CLA=0x00 for Rev 3
     let apdu = [0x94, 0xa4, 0x04, 0x00, aidBytes.length, ...aidBytes];
@@ -520,7 +521,7 @@ export class CalypsoHandler implements CardHandler {
     sendCommand: (apdu: number[]) => Promise<Response>,
     lid: string
   ): Promise<Response> {
-    const lidBytes = this.hexToBytes(lid);
+    const lidBytes = hexToBytes(lid);
     // SELECT by LID: 94 A4 09 00 02 [LID]
     const apdu = [0x94, 0xa4, 0x09, 0x00, 0x02, ...lidBytes];
     return sendCommand(apdu);
@@ -530,7 +531,7 @@ export class CalypsoHandler implements CardHandler {
     sendCommand: (apdu: number[]) => Promise<Response>,
     tag: string
   ): Promise<Response> {
-    const tagBytes = this.hexToBytes(tag);
+    const tagBytes = hexToBytes(tag);
     // GET DATA: 94 CA [P1] [P2] 00
     const p1 = tagBytes.length > 1 ? tagBytes[0] : 0x00;
     const p2 = tagBytes.length > 1 ? tagBytes[1] : tagBytes[0];
@@ -567,7 +568,7 @@ export class CalypsoHandler implements CardHandler {
       data: allData,
       sw1: 0x90,
       sw2: 0x00,
-      hex: this.bytesToHex(allData),
+      hex: bytesToHex(allData),
     };
   }
 
@@ -594,7 +595,7 @@ export class CalypsoHandler implements CardHandler {
       data: allData,
       sw1: 0x90,
       sw2: 0x00,
-      hex: this.bytesToHex(allData),
+      hex: bytesToHex(allData),
     };
   }
 
@@ -626,7 +627,7 @@ export class CalypsoHandler implements CardHandler {
     const version = data[0];
 
     // Try to extract network/operator ID (typically bytes 1-3)
-    const networkId = this.bytesToHex(data.slice(1, 4));
+    const networkId = bytesToHex(data.slice(1, 4));
 
     return `v${version}, Network: ${networkId}`;
   }
@@ -655,16 +656,4 @@ export class CalypsoHandler implements CardHandler {
       .join('');
   }
 
-  private hexToBytes(hex: string): number[] {
-    const clean = hex.replace(/\s/g, '');
-    const bytes: number[] = [];
-    for (let i = 0; i < clean.length; i += 2) {
-      bytes.push(parseInt(clean.substring(i, i + 2), 16));
-    }
-    return bytes;
-  }
-
-  private bytesToHex(bytes: number[]): string {
-    return bytes.map((b) => b.toString(16).padStart(2, '0')).join('').toUpperCase();
-  }
 }

--- a/src/shared/handlers/eid-handler.ts
+++ b/src/shared/handlers/eid-handler.ts
@@ -16,6 +16,7 @@
  */
 
 import type { Response } from '../types';
+import { hexToBytes, bytesToHex } from '../tlv';
 import type {
   CardHandler,
   CardCommand,
@@ -450,7 +451,7 @@ export class EidHandler implements CardHandler {
     sendCommand: (apdu: number[]) => Promise<Response>,
     aid: string
   ): Promise<Response> {
-    const aidBytes = this.hexToBytes(aid);
+    const aidBytes = hexToBytes(aid);
     const apdu = [0x00, 0xa4, 0x04, 0x0c, aidBytes.length, ...aidBytes];
     return sendCommand(apdu);
   }
@@ -459,7 +460,7 @@ export class EidHandler implements CardHandler {
     sendCommand: (apdu: number[]) => Promise<Response>,
     fileId: string
   ): Promise<Response> {
-    const fileBytes = this.hexToBytes(fileId);
+    const fileBytes = hexToBytes(fileId);
     // SELECT by file ID
     const apdu = [0x00, 0xa4, 0x02, 0x0c, fileBytes.length, ...fileBytes];
     return sendCommand(apdu);
@@ -575,7 +576,7 @@ export class EidHandler implements CardHandler {
       data: allData,
       sw1: 0x90,
       sw2: 0x00,
-      hex: this.bytesToHex(allData),
+      hex: bytesToHex(allData),
     };
   }
 
@@ -634,7 +635,7 @@ export class EidHandler implements CardHandler {
       data: infoBytes,
       sw1: 0x90,
       sw2: 0x00,
-      hex: this.bytesToHex(infoBytes),
+      hex: bytesToHex(infoBytes),
       meaning: infoStr,
     };
   }
@@ -675,20 +676,7 @@ export class EidHandler implements CardHandler {
       data: [],
       sw1,
       sw2,
-      hex: this.bytesToHex([sw1, sw2]),
+      hex: bytesToHex([sw1, sw2]),
     };
-  }
-
-  private hexToBytes(hex: string): number[] {
-    const clean = hex.replace(/\s/g, '');
-    const bytes: number[] = [];
-    for (let i = 0; i < clean.length; i += 2) {
-      bytes.push(parseInt(clean.substring(i, i + 2), 16));
-    }
-    return bytes;
-  }
-
-  private bytesToHex(bytes: number[]): string {
-    return bytes.map((b) => b.toString(16).padStart(2, '0')).join('').toUpperCase();
   }
 }

--- a/src/shared/handlers/emv-handler.ts
+++ b/src/shared/handlers/emv-handler.ts
@@ -12,7 +12,7 @@ import type {
   InterrogationResult,
   ApplicationInfo,
 } from './types';
-import { parseTlv, findTag, findTags, getValueHex } from '../tlv';
+import { parseTlv, findTag, findTags, getValueHex, hexToBytes } from '../tlv';
 import {
   buildSelectCommand,
   buildReadRecordCommand,
@@ -288,7 +288,7 @@ export class EmvHandler implements CardHandler {
 
       case 'get-data': {
         const tag = parameters.tag as string;
-        const tagBytes = this.hexToBytes(tag);
+        const tagBytes = hexToBytes(tag);
         // GET DATA: 80 CA P1 P2 00
         const p1 = tagBytes.length > 1 ? tagBytes[0] : 0x00;
         const p2 = tagBytes.length > 1 ? tagBytes[1] : tagBytes[0];
@@ -311,7 +311,7 @@ export class EmvHandler implements CardHandler {
       }
 
       case 'internal-authenticate': {
-        const data = this.hexToBytes(parameters.data as string);
+        const data = hexToBytes(parameters.data as string);
         // INTERNAL AUTHENTICATE: 00 88 00 00 Lc [data] 00
         return sendCommand([0x00, 0x88, 0x00, 0x00, data.length, ...data, 0x00]);
       }
@@ -508,15 +508,6 @@ export class EmvHandler implements CardHandler {
         }
       }
     }
-  }
-
-  private hexToBytes(hex: string): number[] {
-    const cleanHex = hex.replace(/\s/g, '');
-    const bytes: number[] = [];
-    for (let i = 0; i < cleanHex.length; i += 2) {
-      bytes.push(parseInt(cleanHex.substring(i, i + 2), 16));
-    }
-    return bytes;
   }
 
   private buildPinBlock(pin: string): number[] {

--- a/src/shared/handlers/fido-handler.ts
+++ b/src/shared/handlers/fido-handler.ts
@@ -4,6 +4,7 @@
  */
 
 import type { Response } from '../types';
+import { hexToBytes } from '../tlv';
 import type {
   CardHandler,
   CardCommand,
@@ -293,16 +294,16 @@ export class FidoHandler implements CardHandler {
       }
 
       case 'u2f-register': {
-        const challenge = this.hexToBytes(parameters.challenge as string);
-        const appId = this.hexToBytes(parameters.appId as string);
+        const challenge = hexToBytes(parameters.challenge as string);
+        const appId = hexToBytes(parameters.appId as string);
         const data = [...challenge, ...appId];
         return sendCommand([0x00, FIDO_INS.U2F_REGISTER, 0x00, 0x00, data.length, ...data, 0x00]);
       }
 
       case 'u2f-authenticate-check': {
-        const challenge = this.hexToBytes(parameters.challenge as string);
-        const appId = this.hexToBytes(parameters.appId as string);
-        const keyHandle = this.hexToBytes(parameters.keyHandle as string);
+        const challenge = hexToBytes(parameters.challenge as string);
+        const appId = hexToBytes(parameters.appId as string);
+        const keyHandle = hexToBytes(parameters.keyHandle as string);
         const data = [...challenge, ...appId, keyHandle.length, ...keyHandle];
         // P1 = 0x07 = check-only (don't require user presence)
         return sendCommand([
@@ -317,9 +318,9 @@ export class FidoHandler implements CardHandler {
       }
 
       case 'u2f-authenticate': {
-        const challenge = this.hexToBytes(parameters.challenge as string);
-        const appId = this.hexToBytes(parameters.appId as string);
-        const keyHandle = this.hexToBytes(parameters.keyHandle as string);
+        const challenge = hexToBytes(parameters.challenge as string);
+        const appId = hexToBytes(parameters.appId as string);
+        const keyHandle = hexToBytes(parameters.keyHandle as string);
         const data = [...challenge, ...appId, keyHandle.length, ...keyHandle];
         // P1 = 0x03 = enforce-user-presence-and-sign
         return sendCommand([
@@ -335,7 +336,7 @@ export class FidoHandler implements CardHandler {
 
       case 'ctap2-make-credential': {
         // Build CBOR for authenticatorMakeCredential
-        const clientDataHash = this.hexToBytes(parameters.clientDataHash as string);
+        const clientDataHash = hexToBytes(parameters.clientDataHash as string);
         const rpId = parameters.rpId as string;
         const userName = parameters.userName as string;
 
@@ -345,7 +346,7 @@ export class FidoHandler implements CardHandler {
       }
 
       case 'ctap2-get-assertion': {
-        const clientDataHash = this.hexToBytes(parameters.clientDataHash as string);
+        const clientDataHash = hexToBytes(parameters.clientDataHash as string);
         const rpId = parameters.rpId as string;
 
         // Simplified CBOR encoding
@@ -409,17 +410,8 @@ export class FidoHandler implements CardHandler {
   }
 
   private buildSelectCommand(aid: string): number[] {
-    const aidBytes = this.hexToBytes(aid);
+    const aidBytes = hexToBytes(aid);
     return [0x00, 0xa4, 0x04, 0x00, aidBytes.length, ...aidBytes];
-  }
-
-  private hexToBytes(hex: string): number[] {
-    const cleanHex = hex.replace(/\s/g, '');
-    const bytes: number[] = [];
-    for (let i = 0; i < cleanHex.length; i += 2) {
-      bytes.push(parseInt(cleanHex.substring(i, i + 2), 16));
-    }
-    return bytes;
   }
 
   // Simplified CBOR builders - would use a proper CBOR library in production

--- a/src/shared/handlers/health-handler.ts
+++ b/src/shared/handlers/health-handler.ts
@@ -15,6 +15,7 @@
  */
 
 import type { Response } from '../types';
+import { hexToBytes, bytesToHex } from '../tlv';
 import type {
   CardHandler,
   CardCommand,
@@ -439,7 +440,7 @@ export class HealthCardHandler implements CardHandler {
     sendCommand: (apdu: number[]) => Promise<Response>,
     aid: string
   ): Promise<Response> {
-    const aidBytes = this.hexToBytes(aid);
+    const aidBytes = hexToBytes(aid);
     const apdu = [0x00, 0xa4, 0x04, 0x00, aidBytes.length, ...aidBytes, 0x00];
     return sendCommand(apdu);
   }
@@ -448,7 +449,7 @@ export class HealthCardHandler implements CardHandler {
     sendCommand: (apdu: number[]) => Promise<Response>,
     fileId: string
   ): Promise<Response> {
-    const fileBytes = this.hexToBytes(fileId);
+    const fileBytes = hexToBytes(fileId);
     const apdu = [0x00, 0xa4, 0x02, 0x0c, fileBytes.length, ...fileBytes];
     return sendCommand(apdu);
   }
@@ -593,7 +594,7 @@ export class HealthCardHandler implements CardHandler {
       data: allData,
       sw1: 0x90,
       sw2: 0x00,
-      hex: this.bytesToHex(allData),
+      hex: bytesToHex(allData),
     };
   }
 
@@ -640,20 +641,7 @@ export class HealthCardHandler implements CardHandler {
       data: [],
       sw1,
       sw2,
-      hex: this.bytesToHex([sw1, sw2]),
+      hex: bytesToHex([sw1, sw2]),
     };
-  }
-
-  private hexToBytes(hex: string): number[] {
-    const clean = hex.replace(/\s/g, '');
-    const bytes: number[] = [];
-    for (let i = 0; i < clean.length; i += 2) {
-      bytes.push(parseInt(clean.substring(i, i + 2), 16));
-    }
-    return bytes;
-  }
-
-  private bytesToHex(bytes: number[]): string {
-    return bytes.map((b) => b.toString(16).padStart(2, '0')).join('').toUpperCase();
   }
 }

--- a/src/shared/handlers/javacard-handler.ts
+++ b/src/shared/handlers/javacard-handler.ts
@@ -8,6 +8,7 @@
  */
 
 import type { Response } from '../types';
+import { hexToBytes, bytesToHex } from '../tlv';
 import type {
   CardHandler,
   CardCommand,
@@ -450,7 +451,7 @@ export class JavaCardHandler implements CardHandler {
     sendCommand: (apdu: number[]) => Promise<Response>,
     aid: string
   ): Promise<Response> {
-    const aidBytes = this.hexToBytes(aid);
+    const aidBytes = hexToBytes(aid);
     // SELECT by DF name: 00 A4 04 00 Lc [AID] 00
     const apdu = [CLA_ISO, INS.SELECT, 0x04, 0x00, aidBytes.length, ...aidBytes, 0x00];
     const response = await sendCommand(apdu);
@@ -598,7 +599,7 @@ export class JavaCardHandler implements CardHandler {
 
       switch (tag) {
         case 0x4f: // AID
-          aid = this.bytesToHex(value);
+          aid = bytesToHex(value);
           break;
         case 0x9f70: // Life Cycle State (2-byte tag)
           // Handle 2-byte tag
@@ -637,18 +638,5 @@ export class JavaCardHandler implements CardHandler {
       response.sw1 === 0x61 ||
       (response.sw1 === 0x63 && response.sw2 === 0x10) // More data available
     );
-  }
-
-  private hexToBytes(hex: string): number[] {
-    const clean = hex.replace(/\s/g, '');
-    const bytes: number[] = [];
-    for (let i = 0; i < clean.length; i += 2) {
-      bytes.push(parseInt(clean.substring(i, i + 2), 16));
-    }
-    return bytes;
-  }
-
-  private bytesToHex(bytes: number[]): string {
-    return bytes.map((b) => b.toString(16).padStart(2, '0')).join('').toUpperCase();
   }
 }

--- a/src/shared/handlers/mifare-classic-handler.ts
+++ b/src/shared/handlers/mifare-classic-handler.ts
@@ -12,6 +12,7 @@
  */
 
 import type { Response } from '../types';
+import { hexToBytes, bytesToHex } from '../tlv';
 import type {
   CardHandler,
   CardCommand,
@@ -272,7 +273,7 @@ export class MifareClassicHandler implements CardHandler {
     try {
       const uidResponse = await sendCommand([0xff, 0xca, 0x00, 0x00, 0x00]);
       if (uidResponse.sw1 === 0x90 && uidResponse.data.length >= 4) {
-        this.uid = this.bytesToHex(uidResponse.data);
+        this.uid = bytesToHex(uidResponse.data);
 
         // Try to determine card type from SAK or ATR
         this.cardType = this.determineCardType(atrUpper, uidResponse.data);
@@ -395,7 +396,7 @@ export class MifareClassicHandler implements CardHandler {
       // Step 1: Get UID
       const uidResponse = await sendCommand([0xff, 0xca, 0x00, 0x00, 0x00]);
       if (uidResponse.sw1 === 0x90) {
-        this.uid = this.bytesToHex(uidResponse.data);
+        this.uid = bytesToHex(uidResponse.data);
         applications.push({
           aid: this.uid,
           name: 'Card UID',
@@ -453,7 +454,7 @@ export class MifareClassicHandler implements CardHandler {
     key: string,
     keySlot: number
   ): Promise<Response> {
-    const keyBytes = this.hexToBytes(key);
+    const keyBytes = hexToBytes(key);
     if (keyBytes.length !== 6) {
       return this.createErrorResponse(0x6a, 0x80);
     }
@@ -510,7 +511,7 @@ export class MifareClassicHandler implements CardHandler {
           data: allData,
           sw1: response.sw1,
           sw2: response.sw2,
-          hex: this.bytesToHex(allData),
+          hex: bytesToHex(allData),
         };
       }
     }
@@ -521,7 +522,7 @@ export class MifareClassicHandler implements CardHandler {
       data: allData,
       sw1: 0x90,
       sw2: 0x00,
-      hex: this.bytesToHex(allData),
+      hex: bytesToHex(allData),
     };
   }
 
@@ -558,7 +559,7 @@ export class MifareClassicHandler implements CardHandler {
       data: allData,
       sw1: 0x90,
       sw2: 0x00,
-      hex: this.bytesToHex(allData),
+      hex: bytesToHex(allData),
     };
   }
 
@@ -621,7 +622,7 @@ export class MifareClassicHandler implements CardHandler {
       data: allData,
       sw1: 0x90,
       sw2: 0x00,
-      hex: this.bytesToHex(allData),
+      hex: bytesToHex(allData),
     };
   }
 
@@ -669,7 +670,7 @@ export class MifareClassicHandler implements CardHandler {
       data: results,
       sw1: 0x90,
       sw2: 0x00,
-      hex: this.bytesToHex(results),
+      hex: bytesToHex(results),
       meaning: this.formatKeyCheckResults(defaultKeys, results),
     };
   }
@@ -712,7 +713,7 @@ export class MifareClassicHandler implements CardHandler {
     if (data.length < 5) return 'Invalid block';
 
     // First 4 bytes are UID (or first part of 7-byte UID)
-    const uid = this.bytesToHex(data.slice(0, 4));
+    const uid = bytesToHex(data.slice(0, 4));
 
     // Byte 4 is BCC (Block Check Character) for 4-byte UID
     // For 7-byte UID, bytes 4-6 are part of UID, byte 7 is BCC
@@ -768,20 +769,7 @@ export class MifareClassicHandler implements CardHandler {
       data: [],
       sw1,
       sw2,
-      hex: this.bytesToHex([sw1, sw2]),
+      hex: bytesToHex([sw1, sw2]),
     };
-  }
-
-  private hexToBytes(hex: string): number[] {
-    const clean = hex.replace(/\s/g, '');
-    const bytes: number[] = [];
-    for (let i = 0; i < clean.length; i += 2) {
-      bytes.push(parseInt(clean.substring(i, i + 2), 16));
-    }
-    return bytes;
-  }
-
-  private bytesToHex(bytes: number[]): string {
-    return bytes.map((b) => b.toString(16).padStart(2, '0')).join('').toUpperCase();
   }
 }

--- a/src/shared/handlers/openpgp-handler.ts
+++ b/src/shared/handlers/openpgp-handler.ts
@@ -4,6 +4,7 @@
  */
 
 import type { Response } from '../types';
+import { hexToBytes } from '../tlv';
 import type {
   CardHandler,
   CardCommand,
@@ -297,7 +298,7 @@ export class OpenPgpHandler implements CardHandler {
       }
 
       case 'internal-authenticate': {
-        const data = this.hexToBytes(parameters.data as string);
+        const data = hexToBytes(parameters.data as string);
         // INTERNAL AUTHENTICATE: 00 88 00 00 Lc [data] Le
         return sendCommand([0x00, 0x88, 0x00, 0x00, data.length, ...data, 0x00]);
       }
@@ -358,12 +359,12 @@ export class OpenPgpHandler implements CardHandler {
   }
 
   private buildSelectCommand(aid: string): number[] {
-    const aidBytes = this.hexToBytes(aid);
+    const aidBytes = hexToBytes(aid);
     return [0x00, 0xa4, 0x04, 0x00, aidBytes.length, ...aidBytes];
   }
 
   private buildGetDataCommand(tag: string): number[] {
-    const tagBytes = this.hexToBytes(tag);
+    const tagBytes = hexToBytes(tag);
     // GET DATA: 00 CA [P1 P2] Le
     // For OpenPGP, tag is split into P1 and P2
     const p1 = tagBytes.length > 1 ? tagBytes[0] : 0x00;
@@ -375,14 +376,5 @@ export class OpenPgpHandler implements CardHandler {
     const pinBytes = Array.from(pin).map((c) => c.charCodeAt(0));
     // VERIFY: 00 20 00 [PW ref] Lc [PIN]
     return [0x00, 0x20, 0x00, pwRef, pinBytes.length, ...pinBytes];
-  }
-
-  private hexToBytes(hex: string): number[] {
-    const cleanHex = hex.replace(/\s/g, '');
-    const bytes: number[] = [];
-    for (let i = 0; i < cleanHex.length; i += 2) {
-      bytes.push(parseInt(cleanHex.substring(i, i + 2), 16));
-    }
-    return bytes;
   }
 }

--- a/src/shared/handlers/piv-handler.ts
+++ b/src/shared/handlers/piv-handler.ts
@@ -11,6 +11,7 @@ import type {
   DetectionResult,
   InterrogationResult,
 } from './types';
+import { hexToBytes } from '../tlv';
 
 /**
  * PIV Application ID.
@@ -315,12 +316,12 @@ export class PivHandler implements CardHandler {
   }
 
   private buildSelectCommand(aid: string): number[] {
-    const aidBytes = this.hexToBytes(aid);
+    const aidBytes = hexToBytes(aid);
     return [0x00, 0xa4, 0x04, 0x00, aidBytes.length, ...aidBytes];
   }
 
   private buildGetDataCommand(tag: string): number[] {
-    const tagBytes = this.hexToBytes(tag);
+    const tagBytes = hexToBytes(tag);
     // GET DATA: 00 CB 3F FF Lc [5C len tag] Le
     const data = [0x5c, tagBytes.length, ...tagBytes];
     return [0x00, 0xcb, 0x3f, 0xff, data.length, ...data, 0x00];
@@ -334,14 +335,5 @@ export class PivHandler implements CardHandler {
     }
     // VERIFY: 00 20 00 80 08 [PIN]
     return [0x00, 0x20, 0x00, 0x80, 0x08, ...pinBytes];
-  }
-
-  private hexToBytes(hex: string): number[] {
-    const cleanHex = hex.replace(/\s/g, '');
-    const bytes: number[] = [];
-    for (let i = 0; i < cleanHex.length; i += 2) {
-      bytes.push(parseInt(cleanHex.substring(i, i + 2), 16));
-    }
-    return bytes;
   }
 }

--- a/src/shared/handlers/pki-handler.ts
+++ b/src/shared/handlers/pki-handler.ts
@@ -15,6 +15,7 @@
  */
 
 import type { Response } from '../types';
+import { hexToBytes, bytesToHex } from '../tlv';
 import type {
   CardHandler,
   CardCommand,
@@ -511,7 +512,7 @@ export class PkiHandler implements CardHandler {
     sendCommand: (apdu: number[]) => Promise<Response>,
     aid: string
   ): Promise<Response> {
-    const aidBytes = this.hexToBytes(aid);
+    const aidBytes = hexToBytes(aid);
     const apdu = [0x00, 0xa4, 0x04, 0x00, aidBytes.length, ...aidBytes, 0x00];
     return sendCommand(apdu);
   }
@@ -520,7 +521,7 @@ export class PkiHandler implements CardHandler {
     sendCommand: (apdu: number[]) => Promise<Response>,
     fileId: string
   ): Promise<Response> {
-    const fileBytes = this.hexToBytes(fileId);
+    const fileBytes = hexToBytes(fileId);
     const apdu = [0x00, 0xa4, 0x02, 0x0c, fileBytes.length, ...fileBytes];
     return sendCommand(apdu);
   }
@@ -691,7 +692,7 @@ export class PkiHandler implements CardHandler {
       data: allData,
       sw1: 0x90,
       sw2: 0x00,
-      hex: this.bytesToHex(allData),
+      hex: bytesToHex(allData),
     };
   }
 
@@ -792,20 +793,7 @@ export class PkiHandler implements CardHandler {
       data: [],
       sw1,
       sw2,
-      hex: this.bytesToHex([sw1, sw2]),
+      hex: bytesToHex([sw1, sw2]),
     };
-  }
-
-  private hexToBytes(hex: string): number[] {
-    const clean = hex.replace(/\s/g, '');
-    const bytes: number[] = [];
-    for (let i = 0; i < clean.length; i += 2) {
-      bytes.push(parseInt(clean.substring(i, i + 2), 16));
-    }
-    return bytes;
-  }
-
-  private bytesToHex(bytes: number[]): string {
-    return bytes.map((b) => b.toString(16).padStart(2, '0')).join('').toUpperCase();
   }
 }

--- a/src/shared/handlers/sim-handler.ts
+++ b/src/shared/handlers/sim-handler.ts
@@ -16,6 +16,7 @@ import type {
   InterrogationResult,
   ApplicationInfo,
 } from './types';
+import { bytesToHex } from '../tlv';
 
 /**
  * SIM card class byte (GSM 11.11).
@@ -735,7 +736,7 @@ export class SimHandler implements CardHandler {
       const len = data[offset + 1];
 
       if (tag === 0x4f && len > 0) {
-        const aid = this.bytesToHex(data.slice(offset + 2, offset + 2 + len));
+        const aid = bytesToHex(data.slice(offset + 2, offset + 2 + len));
         let label: string | undefined;
 
         // Look for label (tag 50)
@@ -771,9 +772,5 @@ export class SimHandler implements CardHandler {
     if (aidUpper.startsWith('A0000000090001')) return 'Visa Payment';
     if (aidUpper.startsWith('A0000000041010')) return 'Mastercard Payment';
     return 'Unknown Application';
-  }
-
-  private bytesToHex(bytes: number[]): string {
-    return bytes.map((b) => b.toString(16).padStart(2, '0')).join('').toUpperCase();
   }
 }


### PR DESCRIPTION
## Summary
- Consolidated duplicate `hexToBytes` and `bytesToHex` implementations across 13 files
- All handlers now import from `src/shared/tlv.ts` as the single source of truth
- Removed ~130 lines of duplicate code

## Files modified
- `src/shared/emv.ts` - removed local hexToBytes, now imports from tlv
- All 12 card handlers - removed private methods, now import from tlv

## Test plan
- [x] All 163 existing tests pass
- [x] No TypeScript errors introduced (pre-existing errors remain)
- [x] Functionality preserved - same implementation, just centralized

Closes #44