### PR TITLE
fix: add input validation to REPL command

### DIFF
--- a/src/main/smartcard-service.ts
+++ b/src/main/smartcard-service.ts
@@ -1,7 +1,7 @@
 import { BrowserWindow } from 'electron';
 import { Devices, Card, Reader } from 'smartcard';
 import type { Device, Command, Response } from '../shared/types';
-import { getStatusWordInfo } from '../shared/apdu';
+import { getStatusWordInfo, parseHexInput } from '../shared/apdu';
 import {
   globalRegistry,
   registerBuiltinHandlers,
@@ -187,14 +187,10 @@ export class SmartcardService {
   }
 
   async repl(command: string): Promise<Response> {
-    // Parse hex string to byte array
-    const cleaned = command.replace(/0x/gi, '').replace(/,/g, '').replace(/\s+/g, '').toUpperCase();
-
-    const bytes: number[] = [];
-    for (let i = 0; i < cleaned.length; i += 2) {
-      bytes.push(parseInt(cleaned.substring(i, i + 2), 16));
+    const bytes = parseHexInput(command);
+    if (!bytes) {
+      throw new Error('Invalid hex input: must be valid hex characters with even length');
     }
-
     return this.sendCommand(bytes);
   }
 


### PR DESCRIPTION
## Summary
- Use `parseHexInput` from `shared/apdu.ts` instead of inline parsing
- Properly validates hex characters and even-length input
- Returns helpful error message for invalid input

## Problem
Previously, invalid input like 'hello' would produce NaN bytes that would be passed to sendCommand.

## Solution
Use the shared `parseHexInput` function which returns `null` for invalid input, then throw a descriptive error.

## Test plan
- [x] All 163 tests pass (parseHexInput has comprehensive tests)
- [x] Invalid input now properly rejected

Closes #48