### PR TITLE
test: add unit tests for EmvHandler and HandlerRegistry

### DIFF
--- a/src/shared/handlers/emv-handler.test.ts
+++ b/src/shared/handlers/emv-handler.test.ts
@@ -1,0 +1,217 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { EmvHandler } from './emv-handler';
+import type { Response } from '../types';
+
+// Helper to create mock responses
+function createMockResponse(sw1: number, sw2: number, data: number[] = []): Response {
+  return {
+    id: 'test',
+    timestamp: Date.now(),
+    data,
+    sw1,
+    sw2,
+    hex: [...data, sw1, sw2].map((b) => b.toString(16).padStart(2, '0')).join('').toUpperCase(),
+  };
+}
+
+describe('EmvHandler', () => {
+  let handler: EmvHandler;
+
+  beforeEach(() => {
+    handler = new EmvHandler();
+  });
+
+  describe('metadata', () => {
+    it('should have correct id', () => {
+      expect(handler.id).toBe('emv');
+    });
+
+    it('should have correct name', () => {
+      expect(handler.name).toBe('EMV Payment Card');
+    });
+
+    it('should have description', () => {
+      expect(handler.description).toContain('payment');
+    });
+  });
+
+  describe('detect', () => {
+    it('should detect EMV contact card when PSE select succeeds', async () => {
+      const mockSendCommand = vi.fn().mockResolvedValue(createMockResponse(0x90, 0x00));
+
+      const result = await handler.detect('3B6500002063CB6600', mockSendCommand);
+
+      expect(result.detected).toBe(true);
+      expect(result.confidence).toBe(95);
+      expect(result.cardType).toBe('EMV Contact Card');
+      expect(result.metadata?.environment).toBe('pse');
+    });
+
+    it('should detect EMV contactless card when PPSE select succeeds', async () => {
+      const mockSendCommand = vi
+        .fn()
+        .mockRejectedValueOnce(new Error('PSE failed')) // First call (PSE) fails
+        .mockResolvedValueOnce(createMockResponse(0x90, 0x00)); // Second call (PPSE) succeeds
+
+      const result = await handler.detect('3B6500002063CB6600', mockSendCommand);
+
+      expect(result.detected).toBe(true);
+      expect(result.confidence).toBe(95);
+      expect(result.cardType).toBe('EMV Contactless Card');
+      expect(result.metadata?.environment).toBe('ppse');
+    });
+
+    it('should detect EMV card with 61XX response (more data)', async () => {
+      const mockSendCommand = vi.fn().mockResolvedValue(createMockResponse(0x61, 0x10));
+
+      const result = await handler.detect('3B6500002063CB6600', mockSendCommand);
+
+      expect(result.detected).toBe(true);
+      expect(result.confidence).toBe(95);
+    });
+
+    it('should return low confidence for ATR-only detection', async () => {
+      // Both PSE and PPSE fail, but ATR looks like EMV
+      const mockSendCommand = vi.fn().mockResolvedValue(createMockResponse(0x6a, 0x82));
+
+      const result = await handler.detect('3B8080019080', mockSendCommand);
+
+      expect(result.detected).toBe(true);
+      expect(result.confidence).toBe(30);
+      expect(result.cardType).toBe('Possible EMV Card');
+    });
+
+    it('should return not detected for non-EMV cards', async () => {
+      const mockSendCommand = vi.fn().mockResolvedValue(createMockResponse(0x6a, 0x82));
+
+      const result = await handler.detect('3B00', mockSendCommand);
+
+      expect(result.detected).toBe(false);
+      expect(result.confidence).toBe(0);
+    });
+  });
+
+  describe('getCommands', () => {
+    it('should return command list', () => {
+      const commands = handler.getCommands();
+
+      expect(commands.length).toBeGreaterThan(0);
+      expect(commands.find((c) => c.id === 'select-pse')).toBeDefined();
+      expect(commands.find((c) => c.id === 'select-ppse')).toBeDefined();
+      expect(commands.find((c) => c.id === 'get-processing-options')).toBeDefined();
+    });
+
+    it('should have discovery category commands', () => {
+      const commands = handler.getCommands();
+      const discoveryCommands = commands.filter((c) => c.category === 'Discovery');
+
+      expect(discoveryCommands.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('executeCommand', () => {
+    it('should execute select-pse command', async () => {
+      const mockSendCommand = vi.fn().mockResolvedValue(createMockResponse(0x90, 0x00));
+      const context = {
+        sendCommand: mockSendCommand,
+        atr: '3B00',
+        protocol: 1,
+        parameters: {},
+      };
+
+      await handler.executeCommand('select-pse', context);
+
+      expect(mockSendCommand).toHaveBeenCalled();
+      // Check the APDU was for PSE select (1PAY.SYS.DDF01)
+      const apdu = mockSendCommand.mock.calls[0][0];
+      expect(apdu[0]).toBe(0x00); // CLA
+      expect(apdu[1]).toBe(0xa4); // INS (SELECT)
+      expect(apdu[2]).toBe(0x04); // P1
+      expect(apdu[3]).toBe(0x00); // P2
+    });
+
+    it('should execute select-ppse command', async () => {
+      const mockSendCommand = vi.fn().mockResolvedValue(createMockResponse(0x90, 0x00));
+      const context = {
+        sendCommand: mockSendCommand,
+        atr: '3B00',
+        protocol: 1,
+        parameters: {},
+      };
+
+      await handler.executeCommand('select-ppse', context);
+
+      expect(mockSendCommand).toHaveBeenCalled();
+      const apdu = mockSendCommand.mock.calls[0][0];
+      expect(apdu[0]).toBe(0x00);
+      expect(apdu[1]).toBe(0xa4);
+    });
+
+    it('should execute select-application with AID parameter', async () => {
+      const mockSendCommand = vi.fn().mockResolvedValue(createMockResponse(0x90, 0x00));
+      const context = {
+        sendCommand: mockSendCommand,
+        atr: '3B00',
+        protocol: 1,
+        parameters: { aid: 'A0000000041010' },
+      };
+
+      await handler.executeCommand('select-application', context);
+
+      expect(mockSendCommand).toHaveBeenCalled();
+      const apdu = mockSendCommand.mock.calls[0][0];
+      // Check AID bytes are in the APDU
+      expect(apdu).toContain(0xa0);
+      expect(apdu).toContain(0x00);
+      expect(apdu).toContain(0x04);
+    });
+
+    it('should execute get-processing-options', async () => {
+      const mockSendCommand = vi.fn().mockResolvedValue(createMockResponse(0x90, 0x00));
+      const context = {
+        sendCommand: mockSendCommand,
+        atr: '3B00',
+        protocol: 1,
+        parameters: {},
+      };
+
+      await handler.executeCommand('get-processing-options', context);
+
+      expect(mockSendCommand).toHaveBeenCalled();
+      const apdu = mockSendCommand.mock.calls[0][0];
+      expect(apdu[0]).toBe(0x80); // CLA
+      expect(apdu[1]).toBe(0xa8); // INS (GPO)
+    });
+
+    it('should execute read-record with parameters', async () => {
+      const mockSendCommand = vi.fn().mockResolvedValue(createMockResponse(0x90, 0x00));
+      const context = {
+        sendCommand: mockSendCommand,
+        atr: '3B00',
+        protocol: 1,
+        parameters: { sfi: 1, record: 1 },
+      };
+
+      await handler.executeCommand('read-record', context);
+
+      expect(mockSendCommand).toHaveBeenCalled();
+      const apdu = mockSendCommand.mock.calls[0][0];
+      expect(apdu[0]).toBe(0x00); // CLA
+      expect(apdu[1]).toBe(0xb2); // INS (READ RECORD)
+      expect(apdu[2]).toBe(1); // P1 (record number)
+    });
+
+    it('should throw for unknown command', async () => {
+      const context = {
+        sendCommand: vi.fn(),
+        atr: '3B00',
+        protocol: 1,
+        parameters: {},
+      };
+
+      await expect(handler.executeCommand('unknown-command', context)).rejects.toThrow(
+        'Unknown command'
+      );
+    });
+  });
+});

--- a/src/shared/handlers/registry.test.ts
+++ b/src/shared/handlers/registry.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { HandlerRegistry } from './registry';
+import type { CardHandler, DetectionResult, InterrogationResult } from './types';
+import type { Response } from '../types';
+
+// Helper to create mock responses
+function createMockResponse(sw1: number, sw2: number, data: number[] = []): Response {
+  return {
+    id: 'test',
+    timestamp: Date.now(),
+    data,
+    sw1,
+    sw2,
+    hex: [...data, sw1, sw2].map((b) => b.toString(16).padStart(2, '0')).join('').toUpperCase(),
+  };
+}
+
+// Create a mock handler
+function createMockHandler(
+  id: string,
+  detectionResult: DetectionResult
+): CardHandler {
+  return {
+    id,
+    name: `${id} Handler`,
+    description: `Mock ${id} handler`,
+    detect: vi.fn().mockResolvedValue(detectionResult),
+    getCommands: vi.fn().mockReturnValue([]),
+    executeCommand: vi.fn().mockResolvedValue(createMockResponse(0x90, 0x00)),
+    interrogate: vi.fn().mockResolvedValue({ success: true } as InterrogationResult),
+  };
+}
+
+describe('HandlerRegistry', () => {
+  let registry: HandlerRegistry;
+
+  beforeEach(() => {
+    registry = new HandlerRegistry();
+  });
+
+  describe('register', () => {
+    it('should register a handler', () => {
+      const handler = createMockHandler('test', { detected: true, confidence: 80 });
+
+      registry.register(handler, 50);
+
+      const handlers = registry.getAllHandlers();
+      expect(handlers).toHaveLength(1);
+      expect(handlers[0].id).toBe('test');
+    });
+
+    it('should register multiple handlers', () => {
+      const handler1 = createMockHandler('test1', { detected: true, confidence: 80 });
+      const handler2 = createMockHandler('test2', { detected: true, confidence: 90 });
+
+      registry.register(handler1, 50);
+      registry.register(handler2, 60);
+
+      const handlers = registry.getAllHandlers();
+      expect(handlers).toHaveLength(2);
+    });
+  });
+
+  describe('detectHandlers', () => {
+    it('should detect handlers that match the card', async () => {
+      const handler = createMockHandler('test', {
+        detected: true,
+        confidence: 80,
+        cardType: 'Test Card',
+      });
+      registry.register(handler, 50);
+
+      const mockSendCommand = vi.fn().mockResolvedValue(createMockResponse(0x90, 0x00));
+      const detected = await registry.detectHandlers('3B00', mockSendCommand);
+
+      expect(detected).toHaveLength(1);
+      expect(detected[0].handler.id).toBe('test');
+      expect(detected[0].result.confidence).toBe(80);
+    });
+
+    it('should not include handlers that do not detect', async () => {
+      const handler = createMockHandler('test', { detected: false, confidence: 0 });
+      registry.register(handler, 50);
+
+      const mockSendCommand = vi.fn().mockResolvedValue(createMockResponse(0x90, 0x00));
+      const detected = await registry.detectHandlers('3B00', mockSendCommand);
+
+      expect(detected).toHaveLength(0);
+    });
+
+    it('should sort detected handlers by confidence (descending)', async () => {
+      const handler1 = createMockHandler('high-confidence', {
+        detected: true,
+        confidence: 95,
+      });
+      const handler2 = createMockHandler('low-confidence', {
+        detected: true,
+        confidence: 60,
+      });
+
+      registry.register(handler1, 30);
+      registry.register(handler2, 70);
+
+      const mockSendCommand = vi.fn().mockResolvedValue(createMockResponse(0x90, 0x00));
+      const detected = await registry.detectHandlers('3B00', mockSendCommand);
+
+      expect(detected).toHaveLength(2);
+      // Sorted by confidence, not priority
+      expect(detected[0].handler.id).toBe('high-confidence');
+      expect(detected[1].handler.id).toBe('low-confidence');
+    });
+
+    it('should handle detection errors gracefully', async () => {
+      const handler1 = createMockHandler('error-handler', { detected: false, confidence: 0 });
+      (handler1.detect as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('Detection failed'));
+
+      const handler2 = createMockHandler('working-handler', {
+        detected: true,
+        confidence: 80,
+      });
+
+      registry.register(handler1, 50);
+      registry.register(handler2, 50);
+
+      const mockSendCommand = vi.fn().mockResolvedValue(createMockResponse(0x90, 0x00));
+      const detected = await registry.detectHandlers('3B00', mockSendCommand);
+
+      // Should still return the working handler
+      expect(detected).toHaveLength(1);
+      expect(detected[0].handler.id).toBe('working-handler');
+    });
+
+    it('should call detect on all registered handlers', async () => {
+      const handler1 = createMockHandler('test1', { detected: true, confidence: 80 });
+      const handler2 = createMockHandler('test2', { detected: true, confidence: 90 });
+
+      registry.register(handler1, 50);
+      registry.register(handler2, 60);
+
+      const mockSendCommand = vi.fn().mockResolvedValue(createMockResponse(0x90, 0x00));
+      await registry.detectHandlers('3B00', mockSendCommand);
+
+      expect(handler1.detect).toHaveBeenCalledWith('3B00', mockSendCommand);
+      expect(handler2.detect).toHaveBeenCalledWith('3B00', mockSendCommand);
+    });
+  });
+
+  describe('getAllHandlers', () => {
+    it('should return empty array when no handlers registered', () => {
+      const handlers = registry.getAllHandlers();
+      expect(handlers).toEqual([]);
+    });
+
+    it('should return handlers sorted by priority (descending)', () => {
+      const handler1 = createMockHandler('low-priority', { detected: false, confidence: 0 });
+      const handler2 = createMockHandler('high-priority', { detected: false, confidence: 0 });
+
+      registry.register(handler1, 30);
+      registry.register(handler2, 70);
+
+      const handlers = registry.getAllHandlers();
+      // Higher priority first
+      expect(handlers[0].id).toBe('high-priority');
+      expect(handlers[1].id).toBe('low-priority');
+    });
+  });
+
+  describe('getHandler', () => {
+    it('should return handler by ID', () => {
+      const handler = createMockHandler('test', { detected: false, confidence: 0 });
+      registry.register(handler, 50);
+
+      const found = registry.getHandler('test');
+      expect(found?.id).toBe('test');
+    });
+
+    it('should return undefined for unknown ID', () => {
+      const found = registry.getHandler('unknown');
+      expect(found).toBeUndefined();
+    });
+  });
+
+  describe('unregister', () => {
+    it('should remove handler by ID', () => {
+      const handler = createMockHandler('test', { detected: false, confidence: 0 });
+      registry.register(handler, 50);
+
+      registry.unregister('test');
+
+      expect(registry.getAllHandlers()).toHaveLength(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Added unit test coverage for card handlers.

## Added tests

### EmvHandler (16 tests)
- Metadata properties (id, name, description)
- Detection logic:
  - PSE select success
  - PPSE select success
  - 61XX response handling
  - ATR-only fallback detection
  - Non-EMV card rejection
- Command execution:
  - select-pse
  - select-ppse
  - select-application with AID
  - get-processing-options
  - read-record with parameters
  - Unknown command error

### HandlerRegistry (12 tests)
- register: single and multiple handlers
- detectHandlers: matching, non-matching, confidence sorting, error handling
- getAllHandlers: empty, priority sorting
- getHandler: by ID, unknown ID
- unregister: removes handler

## Impact
- Test count: 163 → 191 (+28 tests)
- Handler test coverage improved from 0%

## Test plan
- [x] All 191 tests pass

Closes #52