### PR TITLE
refactor: share buildSelectCommand across handlers

### DIFF
--- a/src/shared/handlers/fido-handler.ts
+++ b/src/shared/handlers/fido-handler.ts
@@ -5,6 +5,7 @@
 
 import type { Response } from '../types';
 import { hexToBytes } from '../tlv';
+import { buildSelectCommand } from '../emv';
 import type {
   CardHandler,
   CardCommand,
@@ -238,7 +239,7 @@ export class FidoHandler implements CardHandler {
   ): Promise<DetectionResult> {
     try {
       // Try to select FIDO application
-      const selectCmd = this.buildSelectCommand(FIDO_U2F_AID);
+      const selectCmd = buildSelectCommand(FIDO_U2F_AID);
       const response = await sendCommand(selectCmd);
 
       if (response.sw1 === 0x90 || response.sw1 === 0x61) {
@@ -282,7 +283,7 @@ export class FidoHandler implements CardHandler {
 
     switch (commandId) {
       case 'select-fido':
-        return sendCommand(this.buildSelectCommand(FIDO_U2F_AID));
+        return sendCommand(buildSelectCommand(FIDO_U2F_AID));
 
       case 'get-version':
         return sendCommand([0x00, FIDO_INS.U2F_VERSION, 0x00, 0x00, 0x00]);
@@ -377,7 +378,7 @@ export class FidoHandler implements CardHandler {
   ): Promise<InterrogationResult> {
     try {
       // Select FIDO application
-      const selectResponse = await sendCommand(this.buildSelectCommand(FIDO_U2F_AID));
+      const selectResponse = await sendCommand(buildSelectCommand(FIDO_U2F_AID));
       if (selectResponse.sw1 !== 0x90 && selectResponse.sw1 !== 0x61) {
         return { success: false, error: 'Failed to select FIDO application' };
       }
@@ -407,11 +408,6 @@ export class FidoHandler implements CardHandler {
         error: error instanceof Error ? error.message : 'Unknown error',
       };
     }
-  }
-
-  private buildSelectCommand(aid: string): number[] {
-    const aidBytes = hexToBytes(aid);
-    return [0x00, 0xa4, 0x04, 0x00, aidBytes.length, ...aidBytes];
   }
 
   // Simplified CBOR builders - would use a proper CBOR library in production

--- a/src/shared/handlers/openpgp-handler.ts
+++ b/src/shared/handlers/openpgp-handler.ts
@@ -5,6 +5,7 @@
 
 import type { Response } from '../types';
 import { hexToBytes } from '../tlv';
+import { buildSelectCommand } from '../emv';
 import type {
   CardHandler,
   CardCommand,
@@ -221,7 +222,7 @@ export class OpenPgpHandler implements CardHandler {
   ): Promise<DetectionResult> {
     try {
       // Try to select OpenPGP application
-      const selectCmd = this.buildSelectCommand(OPENPGP_AID);
+      const selectCmd = buildSelectCommand(OPENPGP_AID);
       const response = await sendCommand(selectCmd);
 
       if (response.sw1 === 0x90 || response.sw1 === 0x61) {
@@ -248,7 +249,7 @@ export class OpenPgpHandler implements CardHandler {
 
     switch (commandId) {
       case 'select-openpgp':
-        return sendCommand(this.buildSelectCommand(OPENPGP_AID));
+        return sendCommand(buildSelectCommand(OPENPGP_AID));
 
       case 'get-aid':
         return sendCommand(this.buildGetDataCommand(OPENPGP_OBJECTS.AID));
@@ -319,7 +320,7 @@ export class OpenPgpHandler implements CardHandler {
   ): Promise<InterrogationResult> {
     try {
       // Select OpenPGP application
-      const selectResponse = await sendCommand(this.buildSelectCommand(OPENPGP_AID));
+      const selectResponse = await sendCommand(buildSelectCommand(OPENPGP_AID));
       if (selectResponse.sw1 !== 0x90 && selectResponse.sw1 !== 0x61) {
         return { success: false, error: 'Failed to select OpenPGP application' };
       }
@@ -356,11 +357,6 @@ export class OpenPgpHandler implements CardHandler {
         error: error instanceof Error ? error.message : 'Unknown error',
       };
     }
-  }
-
-  private buildSelectCommand(aid: string): number[] {
-    const aidBytes = hexToBytes(aid);
-    return [0x00, 0xa4, 0x04, 0x00, aidBytes.length, ...aidBytes];
   }
 
   private buildGetDataCommand(tag: string): number[] {

--- a/src/shared/handlers/piv-handler.ts
+++ b/src/shared/handlers/piv-handler.ts
@@ -12,6 +12,7 @@ import type {
   InterrogationResult,
 } from './types';
 import { hexToBytes } from '../tlv';
+import { buildSelectCommand } from '../emv';
 
 /**
  * PIV Application ID.
@@ -185,7 +186,7 @@ export class PivHandler implements CardHandler {
   ): Promise<DetectionResult> {
     try {
       // Try to select PIV application
-      const selectCmd = this.buildSelectCommand(PIV_AID);
+      const selectCmd = buildSelectCommand(PIV_AID);
       const response = await sendCommand(selectCmd);
 
       if (response.sw1 === 0x90 || response.sw1 === 0x61) {
@@ -212,7 +213,7 @@ export class PivHandler implements CardHandler {
 
     switch (commandId) {
       case 'select-piv':
-        return sendCommand(this.buildSelectCommand(PIV_AID));
+        return sendCommand(buildSelectCommand(PIV_AID));
 
       case 'get-chuid':
         return sendCommand(this.buildGetDataCommand(PIV_OBJECTS.CARD_HOLDER_UNIQUE_ID));
@@ -266,7 +267,7 @@ export class PivHandler implements CardHandler {
   ): Promise<InterrogationResult> {
     try {
       // Select PIV application
-      const selectResponse = await sendCommand(this.buildSelectCommand(PIV_AID));
+      const selectResponse = await sendCommand(buildSelectCommand(PIV_AID));
       if (selectResponse.sw1 !== 0x90 && selectResponse.sw1 !== 0x61) {
         return { success: false, error: 'Failed to select PIV application' };
       }
@@ -313,11 +314,6 @@ export class PivHandler implements CardHandler {
         error: error instanceof Error ? error.message : 'Unknown error',
       };
     }
-  }
-
-  private buildSelectCommand(aid: string): number[] {
-    const aidBytes = hexToBytes(aid);
-    return [0x00, 0xa4, 0x04, 0x00, aidBytes.length, ...aidBytes];
   }
 
   private buildGetDataCommand(tag: string): number[] {


### PR DESCRIPTION
## Summary
Update handlers to import `buildSelectCommand` from `emv.ts` instead of having private implementations.

## Changes
- `piv-handler.ts` - removed private method, imports from emv.ts
- `fido-handler.ts` - removed private method, imports from emv.ts
- `openpgp-handler.ts` - removed private method, imports from emv.ts

## Impact
- Removes ~12 lines of duplicate code
- Consistent SELECT command format across all handlers

## Test plan
- [x] All 191 tests pass

Closes #56