### PR TITLE
feat: add React Error Boundaries for graceful error handling

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -21,6 +21,7 @@ import { CardInfoHeader } from './components/CardInfoHeader';
 import { Repl, ReplHandle } from './components/Repl';
 import { KeyboardShortcutsHelp } from './components/KeyboardShortcutsHelp';
 import { ApplicationsPanel, DiscoveredApp } from './components/ApplicationsPanel';
+import { ErrorBoundary } from './components/ErrorBoundary';
 import { parseTlv } from '../shared/tlv';
 import { useKeyboardShortcuts, KeyboardShortcut } from './hooks/useKeyboardShortcuts';
 
@@ -442,22 +443,26 @@ export function App() {
 
               {/* Command Panel */}
               <div className="flex-1 overflow-hidden">
-                <CommandPanel
-                  handlers={activeHandlers}
-                  activeHandlerId={activeHandlerId}
-                  onSelectHandler={handleSelectHandler}
-                  onExecuteCommand={handleExecuteCommand}
-                />
+                <ErrorBoundary>
+                  <CommandPanel
+                    handlers={activeHandlers}
+                    activeHandlerId={activeHandlerId}
+                    onSelectHandler={handleSelectHandler}
+                    onExecuteCommand={handleExecuteCommand}
+                  />
+                </ErrorBoundary>
               </div>
             </div>
 
             {/* Reader Panel - Center */}
-            <ReaderPanel
-              session={activeSession}
-              onInterrogate={handleInterrogate}
-              onClear={handleClearLog}
-              onShowShortcuts={() => setShowShortcutHelp(true)}
-            />
+            <ErrorBoundary>
+              <ReaderPanel
+                session={activeSession}
+                onInterrogate={handleInterrogate}
+                onClear={handleClearLog}
+                onShowShortcuts={() => setShowShortcutHelp(true)}
+              />
+            </ErrorBoundary>
           </>
         ) : devices.length > 0 ? (
           <div className="flex-1 flex items-center justify-center text-muted-foreground">

--- a/src/renderer/components/ErrorBoundary.tsx
+++ b/src/renderer/components/ErrorBoundary.tsx
@@ -1,0 +1,58 @@
+import React, { Component, type ReactNode } from 'react';
+import { AlertTriangle, RefreshCw } from 'lucide-react';
+import { Button } from './ui/button';
+
+interface Props {
+  children: ReactNode;
+  fallback?: ReactNode;
+  onReset?: () => void;
+}
+
+interface State {
+  hasError: boolean;
+  error: Error | null;
+}
+
+export class ErrorBoundary extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = { hasError: false, error: null };
+  }
+
+  static getDerivedStateFromError(error: Error): State {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error, errorInfo: React.ErrorInfo): void {
+    console.error('Error caught by boundary:', error, errorInfo);
+  }
+
+  handleReset = (): void => {
+    this.setState({ hasError: false, error: null });
+    this.props.onReset?.();
+  };
+
+  render(): ReactNode {
+    if (this.state.hasError) {
+      if (this.props.fallback) {
+        return this.props.fallback;
+      }
+
+      return (
+        <div className="flex flex-col items-center justify-center p-8 text-center">
+          <AlertTriangle className="h-12 w-12 text-destructive mb-4" />
+          <h2 className="text-lg font-semibold mb-2">Something went wrong</h2>
+          <p className="text-sm text-muted-foreground mb-4 max-w-md">
+            {this.state.error?.message || 'An unexpected error occurred'}
+          </p>
+          <Button variant="outline" onClick={this.handleReset}>
+            <RefreshCw className="h-4 w-4 mr-2" />
+            Try Again
+          </Button>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}


### PR DESCRIPTION
## Summary
Added ErrorBoundary component to catch JavaScript errors in child components and display a user-friendly fallback UI.

## Changes
- New `ErrorBoundary` component with:
  - Custom fallback UI with error message
  - 'Try Again' button to reset and recover
  - Optional custom fallback and onReset callback
- Wrapped key UI sections: CommandPanel, ReaderPanel

## Benefits
- Errors in one panel won't crash the entire app
- Users can recover from errors without restarting
- Error details logged to console for debugging

## Test plan
- [x] All 191 tests pass
- [x] Error boundary displays fallback UI when error occurs
- [x] Reset button recovers the component

Closes #58