### PR TITLE
Add unit tests for SimHandler, TransportHandler, and FidoHandler

### DIFF
--- a/src/shared/handlers/fido-handler.test.ts
+++ b/src/shared/handlers/fido-handler.test.ts
@@ -1,0 +1,334 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { FidoHandler } from './fido-handler';
+import type { Response } from '../types';
+
+function createMockResponse(sw1: number, sw2: number, data: number[] = []): Response {
+  return {
+    id: 'test',
+    timestamp: Date.now(),
+    data,
+    sw1,
+    sw2,
+    hex: [...data, sw1, sw2].map((b) => b.toString(16).padStart(2, '0')).join('').toUpperCase(),
+  };
+}
+
+describe('FidoHandler', () => {
+  let handler: FidoHandler;
+
+  beforeEach(() => {
+    handler = new FidoHandler();
+  });
+
+  describe('detect', () => {
+    it('should detect FIDO device when select and version succeed', async () => {
+      // Version returns "U2F_V2" as bytes
+      const versionBytes = Array.from('U2F_V2').map((c) => c.charCodeAt(0));
+      const mockSendCommand = vi.fn()
+        .mockResolvedValueOnce(createMockResponse(0x90, 0x00)) // SELECT FIDO
+        .mockResolvedValueOnce(createMockResponse(0x90, 0x00, versionBytes)); // GET VERSION
+
+      const result = await handler.detect('3B8180018080', mockSendCommand);
+
+      expect(result.detected).toBe(true);
+      expect(result.confidence).toBe(95);
+      expect(result.cardType).toContain('FIDO');
+      expect(result.cardType).toContain('U2F_V2');
+      expect(result.metadata?.version).toBe('U2F_V2');
+    });
+
+    it('should detect FIDO device with lower confidence when version fails', async () => {
+      const mockSendCommand = vi.fn()
+        .mockResolvedValueOnce(createMockResponse(0x90, 0x00)) // SELECT succeeds
+        .mockResolvedValueOnce(createMockResponse(0x6a, 0x82)); // VERSION fails
+
+      const result = await handler.detect('3B8180018080', mockSendCommand);
+
+      expect(result.detected).toBe(true);
+      expect(result.confidence).toBe(85);
+      expect(result.cardType).toBe('FIDO Authenticator');
+    });
+
+    it('should detect FIDO with SW1=0x61 (more data available)', async () => {
+      const mockSendCommand = vi.fn()
+        .mockResolvedValueOnce(createMockResponse(0x61, 0x10)) // SELECT with more data
+        .mockResolvedValueOnce(createMockResponse(0x6a, 0x82)); // VERSION fails
+
+      const result = await handler.detect('3B8180018080', mockSendCommand);
+
+      expect(result.detected).toBe(true);
+      expect(result.confidence).toBe(85);
+    });
+
+    it('should not detect when select fails', async () => {
+      const mockSendCommand = vi.fn()
+        .mockResolvedValueOnce(createMockResponse(0x6a, 0x82)); // SELECT fails
+
+      const result = await handler.detect('3B8180018080', mockSendCommand);
+
+      expect(result.detected).toBe(false);
+      expect(result.confidence).toBe(0);
+    });
+
+    it('should not detect when command throws', async () => {
+      const mockSendCommand = vi.fn()
+        .mockRejectedValueOnce(new Error('Connection failed'));
+
+      const result = await handler.detect('3B8180018080', mockSendCommand);
+
+      expect(result.detected).toBe(false);
+      expect(result.confidence).toBe(0);
+    });
+  });
+
+  describe('getCommands', () => {
+    it('should return FIDO commands', () => {
+      const commands = handler.getCommands();
+
+      expect(commands.length).toBeGreaterThan(0);
+      expect(commands.some((c) => c.id === 'select-fido')).toBe(true);
+      expect(commands.some((c) => c.id === 'get-version')).toBe(true);
+      expect(commands.some((c) => c.id === 'ctap2-get-info')).toBe(true);
+      expect(commands.some((c) => c.id === 'u2f-register')).toBe(true);
+      expect(commands.some((c) => c.id === 'u2f-authenticate')).toBe(true);
+    });
+
+    it('should have commands in expected categories', () => {
+      const commands = handler.getCommands();
+      const categories = new Set(commands.map((c) => c.category));
+
+      expect(categories.has('Discovery')).toBe(true);
+      expect(categories.has('Read')).toBe(true);
+      expect(categories.has('Operations')).toBe(true);
+      expect(categories.has('Security')).toBe(true);
+      expect(categories.has('Management')).toBe(true);
+    });
+
+    it('should mark destructive commands appropriately', () => {
+      const commands = handler.getCommands();
+      const resetCmd = commands.find((c) => c.id === 'ctap2-reset');
+
+      expect(resetCmd).toBeDefined();
+      expect(resetCmd?.isDestructive).toBe(true);
+      expect(resetCmd?.requiresConfirmation).toBe(true);
+    });
+  });
+
+  describe('executeCommand', () => {
+    it('should execute select-fido command', async () => {
+      const mockSendCommand = vi.fn()
+        .mockResolvedValueOnce(createMockResponse(0x90, 0x00));
+
+      const context = {
+        sendCommand: mockSendCommand,
+        atr: '3B8180018080',
+        protocol: 0,
+        parameters: {},
+      };
+
+      const result = await handler.executeCommand('select-fido', context);
+
+      expect(result.sw1).toBe(0x90);
+      expect(mockSendCommand).toHaveBeenCalledWith(
+        expect.arrayContaining([0x00, 0xa4, 0x04, 0x00])
+      );
+    });
+
+    it('should execute get-version command', async () => {
+      const versionBytes = Array.from('U2F_V2').map((c) => c.charCodeAt(0));
+      const mockSendCommand = vi.fn()
+        .mockResolvedValueOnce(createMockResponse(0x90, 0x00, versionBytes));
+
+      const context = {
+        sendCommand: mockSendCommand,
+        atr: '3B8180018080',
+        protocol: 0,
+        parameters: {},
+      };
+
+      const result = await handler.executeCommand('get-version', context);
+
+      expect(result.sw1).toBe(0x90);
+      expect(result.data).toEqual(versionBytes);
+      // Verify it sends U2F VERSION command (INS=0x03)
+      expect(mockSendCommand).toHaveBeenCalledWith([0x00, 0x03, 0x00, 0x00, 0x00]);
+    });
+
+    it('should execute ctap2-get-info command', async () => {
+      const mockSendCommand = vi.fn()
+        .mockResolvedValueOnce(createMockResponse(0x90, 0x00, [0x00])); // CTAP2 success status
+
+      const context = {
+        sendCommand: mockSendCommand,
+        atr: '3B8180018080',
+        protocol: 0,
+        parameters: {},
+      };
+
+      const result = await handler.executeCommand('ctap2-get-info', context);
+
+      expect(result.sw1).toBe(0x90);
+      // CTAP2 CBOR command with 0x04 (getInfo)
+      expect(mockSendCommand).toHaveBeenCalledWith([0x80, 0x11, 0x00, 0x00, 1, 0x04, 0x00]);
+    });
+
+    it('should execute u2f-register command with parameters', async () => {
+      const mockSendCommand = vi.fn()
+        .mockResolvedValueOnce(createMockResponse(0x90, 0x00));
+
+      const context = {
+        sendCommand: mockSendCommand,
+        atr: '3B8180018080',
+        protocol: 0,
+        parameters: {
+          challenge: '0102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F20',
+          appId: '0102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F20',
+        },
+      };
+
+      const result = await handler.executeCommand('u2f-register', context);
+
+      expect(result.sw1).toBe(0x90);
+      // U2F REGISTER command (INS=0x01), data = challenge (32) + appId (32) = 64 bytes
+      expect(mockSendCommand).toHaveBeenCalledWith(
+        expect.arrayContaining([0x00, 0x01, 0x00, 0x00, 64])
+      );
+    });
+
+    it('should execute u2f-authenticate-check with check-only flag', async () => {
+      const mockSendCommand = vi.fn()
+        .mockResolvedValueOnce(createMockResponse(0x69, 0x85)); // Conditions not satisfied = credential exists
+
+      const context = {
+        sendCommand: mockSendCommand,
+        atr: '3B8180018080',
+        protocol: 0,
+        parameters: {
+          challenge: '0102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F20',
+          appId: '0102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F20',
+          keyHandle: '0102030405060708',
+        },
+      };
+
+      await handler.executeCommand('u2f-authenticate-check', context);
+
+      // P1=0x07 for check-only
+      expect(mockSendCommand).toHaveBeenCalledWith(
+        expect.arrayContaining([0x00, 0x02, 0x07, 0x00])
+      );
+    });
+
+    it('should execute u2f-authenticate with enforce-presence flag', async () => {
+      const mockSendCommand = vi.fn()
+        .mockResolvedValueOnce(createMockResponse(0x90, 0x00));
+
+      const context = {
+        sendCommand: mockSendCommand,
+        atr: '3B8180018080',
+        protocol: 0,
+        parameters: {
+          challenge: '0102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F20',
+          appId: '0102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F20',
+          keyHandle: '0102030405060708',
+        },
+      };
+
+      await handler.executeCommand('u2f-authenticate', context);
+
+      // P1=0x03 for enforce-user-presence-and-sign
+      expect(mockSendCommand).toHaveBeenCalledWith(
+        expect.arrayContaining([0x00, 0x02, 0x03, 0x00])
+      );
+    });
+
+    it('should execute ctap2-client-pin command', async () => {
+      const mockSendCommand = vi.fn()
+        .mockResolvedValueOnce(createMockResponse(0x90, 0x00));
+
+      const context = {
+        sendCommand: mockSendCommand,
+        atr: '3B8180018080',
+        protocol: 0,
+        parameters: {
+          subCommand: '01', // Get Retries
+        },
+      };
+
+      await handler.executeCommand('ctap2-client-pin', context);
+
+      // CTAP2 command 0x06 (clientPIN)
+      expect(mockSendCommand).toHaveBeenCalledWith(
+        expect.arrayContaining([0x80, 0x11, 0x00, 0x00])
+      );
+    });
+
+    it('should execute ctap2-reset command', async () => {
+      const mockSendCommand = vi.fn()
+        .mockResolvedValueOnce(createMockResponse(0x90, 0x00));
+
+      const context = {
+        sendCommand: mockSendCommand,
+        atr: '3B8180018080',
+        protocol: 0,
+        parameters: {},
+      };
+
+      await handler.executeCommand('ctap2-reset', context);
+
+      // CTAP2 reset command: 0x07
+      expect(mockSendCommand).toHaveBeenCalledWith([0x80, 0x11, 0x00, 0x00, 1, 0x07, 0x00]);
+    });
+
+    it('should throw for unknown command', async () => {
+      const mockSendCommand = vi.fn();
+
+      const context = {
+        sendCommand: mockSendCommand,
+        atr: '3B8180018080',
+        protocol: 0,
+        parameters: {},
+      };
+
+      await expect(handler.executeCommand('unknown-command', context))
+        .rejects.toThrow('Unknown command: unknown-command');
+    });
+  });
+
+  describe('interrogate', () => {
+    it('should interrogate FIDO device successfully', async () => {
+      const versionBytes = Array.from('U2F_V2').map((c) => c.charCodeAt(0));
+      const mockSendCommand = vi.fn()
+        .mockResolvedValueOnce(createMockResponse(0x90, 0x00)) // SELECT
+        .mockResolvedValueOnce(createMockResponse(0x90, 0x00, versionBytes)) // VERSION
+        .mockResolvedValueOnce(createMockResponse(0x90, 0x00)); // CTAP2 GetInfo
+
+      const result = await handler.interrogate(mockSendCommand);
+
+      expect(result.success).toBe(true);
+      expect(result.applications).toBeDefined();
+      expect(result.applications?.length).toBe(1);
+      expect(result.applications?.[0].name).toBe('FIDO Application');
+    });
+
+    it('should fail interrogation when select fails', async () => {
+      const mockSendCommand = vi.fn()
+        .mockResolvedValueOnce(createMockResponse(0x6a, 0x82));
+
+      const result = await handler.interrogate(mockSendCommand);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('Failed to select FIDO application');
+    });
+
+    it('should succeed even when optional commands fail', async () => {
+      const mockSendCommand = vi.fn()
+        .mockResolvedValueOnce(createMockResponse(0x90, 0x00)) // SELECT succeeds
+        .mockRejectedValueOnce(new Error('Version not supported')) // VERSION fails
+        .mockRejectedValueOnce(new Error('CTAP2 not supported')); // CTAP2 fails
+
+      const result = await handler.interrogate(mockSendCommand);
+
+      expect(result.success).toBe(true);
+    });
+  });
+});

--- a/src/shared/handlers/sim-handler.test.ts
+++ b/src/shared/handlers/sim-handler.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { SimHandler } from './sim-handler';
+import type { Response } from '../types';
+
+function createMockResponse(sw1: number, sw2: number, data: number[] = []): Response {
+  return {
+    id: 'test',
+    timestamp: Date.now(),
+    data,
+    sw1,
+    sw2,
+    hex: [...data, sw1, sw2].map((b) => b.toString(16).padStart(2, '0')).join('').toUpperCase(),
+  };
+}
+
+describe('SimHandler', () => {
+  let handler: SimHandler;
+
+  beforeEach(() => {
+    handler = new SimHandler();
+  });
+
+  describe('detect', () => {
+    it('should detect GSM SIM when MF selection and ICCID read succeed', async () => {
+      // Mock: SELECT MF success (9Fxx triggers GET RESPONSE), SELECT ICCID, READ BINARY
+      const mockSendCommand = vi.fn()
+        .mockResolvedValueOnce(createMockResponse(0x9f, 0x10)) // SELECT MF returns 9F (need GET RESPONSE)
+        .mockResolvedValueOnce(createMockResponse(0x90, 0x00)) // GET RESPONSE for MF
+        .mockResolvedValueOnce(createMockResponse(0x9f, 0x0a)) // SELECT ICCID
+        .mockResolvedValueOnce(createMockResponse(0x90, 0x00)) // GET RESPONSE for ICCID
+        .mockResolvedValueOnce(createMockResponse(0x90, 0x00, [
+          0x98, 0x10, 0x01, 0x23, 0x45, 0x67, 0x89, 0x01, 0x23, 0x45, // ICCID bytes
+        ])); // READ BINARY
+
+      const result = await handler.detect('3B9F958031E073FE211F6501060240008171A050', mockSendCommand);
+
+      expect(result.detected).toBe(true);
+      expect(result.confidence).toBeGreaterThanOrEqual(90);
+      expect(result.cardType).toContain('SIM');
+    });
+
+    it('should detect USIM when USIM class byte works', async () => {
+      const mockSendCommand = vi.fn()
+        .mockResolvedValueOnce(createMockResponse(0x6a, 0x82)) // SELECT MF fails with SIM class
+        .mockResolvedValueOnce(createMockResponse(0x90, 0x00)) // SELECT MF succeeds with USIM class
+        .mockResolvedValueOnce(createMockResponse(0x90, 0x00)) // SELECT ICCID
+        .mockResolvedValueOnce(createMockResponse(0x90, 0x00, [
+          0x98, 0x10, 0x01, 0x23, 0x45, 0x67, 0x89, 0x01, 0x23, 0x45,
+        ]));
+
+      const result = await handler.detect('3B9E9680318066B1A50101010346F00381009000', mockSendCommand);
+
+      expect(result.detected).toBe(true);
+      expect(result.cardType).toContain('USIM');
+    });
+
+    it('should return low confidence for SIM-like ATR when selection fails', async () => {
+      const mockSendCommand = vi.fn()
+        .mockResolvedValueOnce(createMockResponse(0x6a, 0x82)) // MF fails
+        .mockResolvedValueOnce(createMockResponse(0x6a, 0x82)); // MF fails with USIM too
+
+      // SIM-like ATR
+      const result = await handler.detect('3B9F958031E073FE211F6501060240008171A050', mockSendCommand);
+
+      expect(result.detected).toBe(true);
+      expect(result.confidence).toBeLessThanOrEqual(50);
+    });
+
+    it('should not detect non-SIM cards', async () => {
+      const mockSendCommand = vi.fn()
+        .mockResolvedValueOnce(createMockResponse(0x6a, 0x82))
+        .mockResolvedValueOnce(createMockResponse(0x6a, 0x82));
+
+      // Non-SIM ATR (EMV card)
+      const result = await handler.detect('3B6700002063CB6600', mockSendCommand);
+
+      expect(result.detected).toBe(false);
+    });
+  });
+
+  describe('getCommands', () => {
+    it('should return SIM commands', () => {
+      const commands = handler.getCommands();
+
+      expect(commands.length).toBeGreaterThan(0);
+      expect(commands.some((c) => c.id === 'read-iccid')).toBe(true);
+      expect(commands.some((c) => c.id === 'read-imsi')).toBe(true);
+      expect(commands.some((c) => c.id === 'verify-pin')).toBe(true);
+    });
+
+    it('should have commands in expected categories', () => {
+      const commands = handler.getCommands();
+      const categories = new Set(commands.map((c) => c.category));
+
+      expect(categories.has('Identification')).toBe(true);
+      expect(categories.has('Security')).toBe(true);
+    });
+  });
+
+  describe('executeCommand', () => {
+    it('should execute read-iccid command', async () => {
+      // read-iccid: selectFile(MF) -> selectFile(ICCID) -> readBinary
+      // Each selectFile may trigger GET RESPONSE if 9Fxx returned
+      const mockSendCommand = vi.fn()
+        .mockResolvedValueOnce(createMockResponse(0x90, 0x00)) // SELECT MF success
+        .mockResolvedValueOnce(createMockResponse(0x90, 0x00)) // SELECT ICCID success
+        .mockResolvedValueOnce(createMockResponse(0x90, 0x00, [
+          0x98, 0x10, 0x92, 0x14, 0x70, 0x00, 0x62, 0x87, 0x83, 0xf4,
+        ])); // READ BINARY
+
+      const context = {
+        sendCommand: mockSendCommand,
+        atr: '3B9F958031E073FE211F6501060240008171A050',
+        protocol: 0,
+        parameters: {},
+      };
+
+      const result = await handler.executeCommand('read-iccid', context);
+
+      expect(result.sw1).toBe(0x90);
+      expect(result.data.length).toBeGreaterThan(0);
+    });
+
+    it('should throw for unknown command', async () => {
+      const mockSendCommand = vi.fn();
+
+      const context = {
+        sendCommand: mockSendCommand,
+        atr: '3B9F958031E073FE211F6501060240008171A050',
+        protocol: 0,
+        parameters: {},
+      };
+
+      await expect(handler.executeCommand('unknown-command', context))
+        .rejects.toThrow('Unknown command: unknown-command');
+    });
+  });
+});

--- a/src/shared/handlers/transport-handler.test.ts
+++ b/src/shared/handlers/transport-handler.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { TransportHandler } from './transport-handler';
+import type { Response } from '../types';
+
+function createMockResponse(sw1: number, sw2: number, data: number[] = []): Response {
+  return {
+    id: 'test',
+    timestamp: Date.now(),
+    data,
+    sw1,
+    sw2,
+    hex: [...data, sw1, sw2].map((b) => b.toString(16).padStart(2, '0')).join('').toUpperCase(),
+  };
+}
+
+describe('TransportHandler', () => {
+  let handler: TransportHandler;
+
+  beforeEach(() => {
+    handler = new TransportHandler();
+  });
+
+  describe('detect', () => {
+    it('should detect DESFire card when GetVersion succeeds', async () => {
+      // DESFire GetVersion returns 3 frames: HW (91 AF), SW (91 AF), Prod (91 00)
+      // sendDesfireCommand handles multi-frame by calling ADDITIONAL_FRAME
+      // After sendDesfireCommand returns, parseVersionInfo calls ADDITIONAL_FRAME twice more
+      const mockSendCommand = vi.fn()
+        // 1. GetVersion command -> returns HW version with AF (more data)
+        .mockResolvedValueOnce(createMockResponse(0x91, 0xaf, [
+          0x04, 0x01, 0x01, 0x01, 0x00, 0x18, 0x05, // Hardware version (7 bytes)
+        ]))
+        // 2. sendDesfireCommand sees AF, automatically sends ADDITIONAL_FRAME
+        .mockResolvedValueOnce(createMockResponse(0x91, 0x00, [
+          0x04, 0x01, 0x01, 0x01, 0x04, 0x18, 0x05, // SW version, no more frames
+        ]))
+        // 3. parseVersionInfo calls sendDesfireCommand(ADDITIONAL_FRAME) for SW frame
+        .mockResolvedValueOnce(createMockResponse(0x91, 0x00, [
+          0x04, 0x01, 0x01, 0x01, 0x04, 0x18, 0x05,
+        ]))
+        // 4. parseVersionInfo calls sendDesfireCommand(ADDITIONAL_FRAME) for production frame
+        .mockResolvedValueOnce(createMockResponse(0x91, 0x00, [
+          0x04, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D,
+        ]));
+
+      const result = await handler.detect('3B8180018080', mockSendCommand);
+
+      expect(result.detected).toBe(true);
+      expect(result.confidence).toBeGreaterThanOrEqual(90);
+      expect(result.cardType).toContain('DESFire');
+    });
+
+    it('should detect transport card when UID read succeeds with DESFire ATR', async () => {
+      const mockSendCommand = vi.fn()
+        .mockResolvedValueOnce(createMockResponse(0x6a, 0x82)) // GetVersion fails
+        .mockResolvedValueOnce(createMockResponse(0x90, 0x00, [
+          0x04, 0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc, // 7-byte UID
+        ]));
+
+      // DESFire-like ATR
+      const result = await handler.detect('3B8180018080', mockSendCommand);
+
+      expect(result.detected).toBe(true);
+      expect(result.confidence).toBeGreaterThanOrEqual(60);
+    });
+
+    it('should return low confidence for DESFire ATR when commands fail', async () => {
+      const mockSendCommand = vi.fn()
+        .mockResolvedValueOnce(createMockResponse(0x6a, 0x82)) // GetVersion fails
+        .mockResolvedValueOnce(createMockResponse(0x6a, 0x82)); // UID fails
+
+      // DESFire-like ATR
+      const result = await handler.detect('3B8180018080', mockSendCommand);
+
+      expect(result.detected).toBe(true);
+      expect(result.confidence).toBeLessThanOrEqual(50);
+    });
+
+    it('should detect Calypso transport cards', async () => {
+      const mockSendCommand = vi.fn()
+        .mockResolvedValueOnce(createMockResponse(0x6a, 0x82))
+        .mockResolvedValueOnce(createMockResponse(0x6a, 0x82));
+
+      // Calypso ATR
+      const result = await handler.detect('3B8F8001805A0A014000FFFFFFFF829000', mockSendCommand);
+
+      expect(result.detected).toBe(true);
+      expect(result.cardType).toContain('Calypso');
+    });
+
+    it('should not detect non-transport cards', async () => {
+      const mockSendCommand = vi.fn()
+        .mockResolvedValueOnce(createMockResponse(0x6a, 0x82))
+        .mockResolvedValueOnce(createMockResponse(0x6a, 0x82));
+
+      // EMV card ATR
+      const result = await handler.detect('3B6700002063CB6600', mockSendCommand);
+
+      expect(result.detected).toBe(false);
+    });
+  });
+
+  describe('getCommands', () => {
+    it('should return transport commands', () => {
+      const commands = handler.getCommands();
+
+      expect(commands.length).toBeGreaterThan(0);
+      expect(commands.some((c) => c.id === 'get-uid')).toBe(true);
+      expect(commands.some((c) => c.id === 'get-version')).toBe(true);
+      expect(commands.some((c) => c.id === 'get-application-ids')).toBe(true);
+    });
+
+    it('should have Identification category commands', () => {
+      const commands = handler.getCommands();
+      const identCommands = commands.filter((c) => c.category === 'Identification');
+
+      expect(identCommands.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('executeCommand', () => {
+    it('should execute get-uid command', async () => {
+      const mockSendCommand = vi.fn()
+        .mockResolvedValueOnce(createMockResponse(0x90, 0x00, [
+          0x04, 0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc,
+        ]));
+
+      const context = {
+        sendCommand: mockSendCommand,
+        atr: '3B8180018080',
+        protocol: 0,
+        parameters: {},
+      };
+
+      const result = await handler.executeCommand('get-uid', context);
+
+      expect(result.sw1).toBe(0x90);
+      expect(result.data.length).toBe(7);
+    });
+
+    it('should execute get-version command', async () => {
+      const mockSendCommand = vi.fn()
+        .mockResolvedValueOnce(createMockResponse(0x91, 0xaf, [
+          0x04, 0x01, 0x01, 0x01, 0x00, 0x18, 0x05,
+        ]))
+        .mockResolvedValueOnce(createMockResponse(0x91, 0xaf, [
+          0x04, 0x01, 0x01, 0x01, 0x04, 0x18, 0x05,
+        ]))
+        .mockResolvedValueOnce(createMockResponse(0x91, 0x00, [
+          0x04, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06,
+        ]));
+
+      const context = {
+        sendCommand: mockSendCommand,
+        atr: '3B8180018080',
+        protocol: 0,
+        parameters: {},
+      };
+
+      const result = await handler.executeCommand('get-version', context);
+
+      // Should aggregate version data
+      expect(result.data.length).toBeGreaterThan(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Added unit tests for `SimHandler` covering detection, command retrieval, and execution (8 tests)
- Added unit tests for `TransportHandler` covering DESFire detection and command handling (9 tests)
- Added unit tests for `FidoHandler` covering U2F/CTAP2 detection and operations (20 tests)

This addresses the test coverage gap identified in code review, bringing handler test coverage from just `EmvHandler` to include all major card type handlers.

## Test Details

### SimHandler (8 tests)
- GSM SIM detection with MF selection and ICCID read
- USIM detection when USIM class byte works
- Low confidence for SIM-like ATR when selection fails
- Non-SIM card rejection
- Command list and category verification
- `read-iccid` command execution

### TransportHandler (9 tests)
- DESFire detection with GetVersion multi-frame handling
- UID-based detection with DESFire ATR
- Low confidence fallback for DESFire ATR when commands fail
- Calypso transport card detection
- Non-transport card rejection
- Command list verification
- `get-uid` and `get-version` command execution

### FidoHandler (20 tests)
- FIDO device detection with version string parsing
- Lower confidence detection when version fails
- Detection with SW1=0x61 response
- Non-detection scenarios
- Command list with category verification
- Destructive command marking (ctap2-reset)
- U2F and CTAP2 command execution
- Interrogation success/failure handling

## Test Plan

- [x] All 256 tests pass
- [x] TypeScript compilation succeeds
- [x] No new lint errors introduced in test files