### PR TITLE
feat: add contextual EMV workflow UI for payment cards

### DIFF
--- a/src/main/smartcard-service.ts
+++ b/src/main/smartcard-service.ts
@@ -231,6 +231,7 @@ export class SmartcardService {
           cardType: h.result.cardType,
           confidence: h.result.confidence,
           commands: h.handler.getCommands(h.result.metadata),
+          workflow: h.handler.workflow,
         })),
       });
 

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -309,7 +309,7 @@ export function App() {
   const activeCard = activeDevice ? cards.get(activeDevice.name) || null : null;
   const activeApplications = activeDevice ? applications.get(activeDevice.name) || [] : [];
   const activeHandler = activeHandlers.find((h) => h.id === activeHandlerId);
-  const isEmvHandler = activeHandlerId === 'emv';
+  const isEmvWorkflow = activeHandler?.workflow === 'emv';
 
   function handleSelectApplication(aid: string) {
     dispatch({ type: 'APPLICATION_SELECTED', aid });
@@ -334,7 +334,7 @@ export function App() {
           <>
             {/* Left Side Panel - Contextual based on handler type */}
             <div className="w-64 border-r border-border flex flex-col bg-card">
-              {isEmvHandler && activeHandler ? (
+              {isEmvWorkflow && activeHandler ? (
                 /* EMV Workflow Panel - guided experience for payment cards */
                 <ErrorBoundary>
                   <EmvWorkflowPanel

--- a/src/renderer/components/ParameterForm.tsx
+++ b/src/renderer/components/ParameterForm.tsx
@@ -1,0 +1,143 @@
+import { AlertTriangle, ChevronLeft } from 'lucide-react';
+import type { CardCommand, CommandParameter } from '../../shared/handlers/types';
+import { Button } from './ui/button';
+
+interface ParameterFormProps {
+  command: CardCommand;
+  parameters: Record<string, string | number | boolean>;
+  onParameterChange: (param: CommandParameter, value: string) => void;
+  onExecute: () => void;
+  onBack: () => void;
+  showConfirm?: boolean;
+  onCancelConfirm?: () => void;
+}
+
+/**
+ * Shared form component for command parameters.
+ * Used by both CommandPanel and EmvWorkflowPanel.
+ */
+export function ParameterForm({
+  command,
+  parameters,
+  onParameterChange,
+  onExecute,
+  onBack,
+  showConfirm = false,
+  onCancelConfirm,
+}: ParameterFormProps) {
+  return (
+    <div className="p-3">
+      {/* Back button and command name */}
+      <button
+        onClick={onBack}
+        className="flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground mb-3"
+      >
+        <ChevronLeft className="h-4 w-4" />
+        Back
+      </button>
+
+      <div className="mb-4">
+        <div className="flex items-center gap-2">
+          <h3 className="font-medium">{command.name}</h3>
+          {command.isDestructive && <AlertTriangle className="h-4 w-4 text-destructive" />}
+        </div>
+        <p className="text-sm text-muted-foreground mt-1">{command.description}</p>
+      </div>
+
+      {/* Parameters */}
+      {command.parameters?.map((param) => (
+        <div key={param.id} className="mb-3">
+          <label className="text-sm text-muted-foreground block mb-1">
+            {param.name}
+            {param.required && <span className="text-destructive ml-1">*</span>}
+          </label>
+
+          {param.type === 'select' ? (
+            <select
+              className="w-full px-2 py-1.5 text-sm bg-background border border-input rounded font-mono"
+              value={(parameters[param.id] as string) ?? param.defaultValue ?? ''}
+              onChange={(e) => onParameterChange(param, e.target.value)}
+            >
+              <option value="">Select...</option>
+              {param.options?.map((opt) => (
+                <option key={opt.value} value={opt.value}>
+                  {opt.label}
+                </option>
+              ))}
+            </select>
+          ) : param.type === 'boolean' ? (
+            <select
+              className="w-full px-2 py-1.5 text-sm bg-background border border-input rounded"
+              value={String(parameters[param.id] ?? param.defaultValue ?? false)}
+              onChange={(e) => onParameterChange(param, e.target.value)}
+            >
+              <option value="false">No</option>
+              <option value="true">Yes</option>
+            </select>
+          ) : (
+            <input
+              type={param.type === 'number' ? 'number' : 'text'}
+              className="w-full px-2 py-1.5 text-sm bg-background border border-input rounded font-mono"
+              placeholder={param.description}
+              value={(parameters[param.id] as string) ?? param.defaultValue ?? ''}
+              onChange={(e) => onParameterChange(param, e.target.value)}
+            />
+          )}
+        </div>
+      ))}
+
+      {/* Confirmation / Execute */}
+      {showConfirm ? (
+        <div className="mt-4 p-3 border border-destructive/50 rounded bg-destructive/10">
+          <p className="text-sm text-destructive mb-2">
+            {command.isDestructive
+              ? 'This action may cause data loss. Are you sure?'
+              : 'Confirm execution?'}
+          </p>
+          <div className="flex gap-2">
+            <Button variant="destructive" size="sm" onClick={onExecute}>
+              Confirm
+            </Button>
+            <Button variant="ghost" size="sm" onClick={onCancelConfirm}>
+              Cancel
+            </Button>
+          </div>
+        </div>
+      ) : (
+        <Button className="w-full mt-4" onClick={onExecute}>
+          Execute
+        </Button>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Parse a string value to the appropriate type based on parameter type.
+ */
+export function parseParameterValue(
+  param: CommandParameter,
+  value: string
+): string | number | boolean {
+  if (param.type === 'number') {
+    return parseInt(value, 10) || 0;
+  } else if (param.type === 'boolean') {
+    return value === 'true';
+  }
+  return value;
+}
+
+/**
+ * Initialize default parameter values for a command.
+ */
+export function initializeParameters(
+  command: CardCommand
+): Record<string, string | number | boolean> {
+  const defaults: Record<string, string | number | boolean> = {};
+  command.parameters?.forEach((p) => {
+    if (p.defaultValue !== undefined) {
+      defaults[p.id] = p.defaultValue;
+    }
+  });
+  return defaults;
+}

--- a/src/shared/handlers/emv-handler.ts
+++ b/src/shared/handlers/emv-handler.ts
@@ -271,6 +271,7 @@ export class EmvHandler implements CardHandler {
   readonly id = 'emv';
   readonly name = 'EMV Payment Card';
   readonly description = 'Europay, Mastercard, Visa payment cards (contact and contactless)';
+  readonly workflow = 'emv' as const;
 
   private discoveredApplications: ApplicationInfo[] = [];
 

--- a/src/shared/handlers/types.ts
+++ b/src/shared/handlers/types.ts
@@ -116,6 +116,9 @@ export interface CardHandler {
   /** Brief description */
   readonly description: string;
 
+  /** UI workflow type - determines which panel style to use */
+  readonly workflow?: 'emv' | 'generic';
+
   /**
    * Detect if this handler can handle the given card.
    * Called with the card's ATR and optionally after a SELECT command.

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -77,6 +77,8 @@ export interface DetectedHandlerInfo {
   cardType?: string;
   confidence: number;
   commands: CardCommand[];
+  /** UI workflow type - determines which panel to show */
+  workflow?: 'emv' | 'generic';
 }
 
 export interface HandlersDetectedEvent {


### PR DESCRIPTION
## TL;DR

Replace generic command panel with a guided workflow for EMV cards, similar to the `tomkp/emv` CLI tool's interactive mode.

## What's changing

When an EMV card is detected, the left panel now shows a step-based workflow instead of a flat command list:

1. **Discovery** - Buttons to select PSE (contact) or PPSE (contactless)
2. **Select App** - List of discovered payment applications (Visa, Mastercard, etc.)
3. **Explore** - Categorized actions (Transaction, Read Data, Security) with full keyboard navigation

Visual progress indicator at the top shows current step and completion status. Non-EMV cards continue to use the existing generic command panel.

## Why?

The existing generic command panel works for any card type but doesn't guide users through the EMV transaction flow. EMV cards have a specific workflow (PSE → App Selection → GPO → Read Records) that's not obvious from a flat command list.

This contextual UI provides progressive disclosure - showing relevant actions based on where you are in the workflow, similar to how the `emv` CLI tool works.

Closes #76