### PR TITLE
Upgrade @electron-forge packages to ^7.10.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,10 +22,10 @@
     "checks": "npm run typecheck && npm run lint && npm run format && npm run test"
   },
   "devDependencies": {
-    "@electron-forge/cli": "^7.6.0",
-    "@electron-forge/maker-dmg": "^7.6.0",
-    "@electron-forge/maker-zip": "^7.6.0",
-    "@electron-forge/plugin-vite": "^7.6.0",
+    "@electron-forge/cli": "^7.10.2",
+    "@electron-forge/maker-dmg": "^7.10.2",
+    "@electron-forge/maker-zip": "^7.10.2",
+    "@electron-forge/plugin-vite": "^7.10.2",
     "@eslint/js": "^9.39.2",
     "@tailwindcss/postcss": "^4.1.18",
     "@types/node": "^22.10.2",


### PR DESCRIPTION
## Summary

- Upgrade minimum version requirement for @electron-forge packages from ^7.6.0 to ^7.10.2

## Changes in 7.6.0 → 7.10.2

**New Features:**
- MSIX Support (v7.10.0) - Experimental Windows MSIX packaging
- pnpm Support (v7.7.0) - Now works with pnpm package manager
- Vite `concurrent` option (v7.9.0) - Helps with OOM issues during multi-target builds

**Bug Fixes:**
- Vite build error propagation
- TypeScript config loading improvements
- Package manager detection fixes
- Yarn Berry compatibility

This is a non-breaking upgrade within the 7.x line.

## Test plan

- [x] `npm run checks` passes (typecheck, lint, format, tests)

Closes #78